### PR TITLE
Support for current Swift tools

### DIFF
--- a/OMMeter/Classes/Extensions/CGColorSpace+Extension.swift
+++ b/OMMeter/Classes/Extensions/CGColorSpace+Extension.swift
@@ -37,6 +37,8 @@ extension CGColorSpaceModel {
             case .indexed:return "Indexed"
             case .pattern:return "Pattern"
             case .XYZ:return "XYZ"
+        @unknown default:
+            fatalError()
         }
     }
 }

--- a/OMMeter/Classes/Extensions/UIFont+Extensions.swift
+++ b/OMMeter/Classes/Extensions/UIFont+Extensions.swift
@@ -15,7 +15,7 @@ extension UIFont {
     
     static func stringSize(s:String,fontName:String,size:CGSize) -> CGSize {
         for i in (1...50).reversed() {
-            let d = [NSAttributedStringKey.font:UIFont(name:fontName, size:CGFloat(i))!]
+            let d = [NSAttributedString.Key.font:UIFont(name:fontName, size:CGFloat(i))!]
             let sz = (s as NSString).size(withAttributes: d)
             if sz.width <= size.width && sz.height <= size.height {
                 return sz

--- a/OMMeter/Classes/OMMeter.swift
+++ b/OMMeter/Classes/OMMeter.swift
@@ -52,7 +52,7 @@ public class OMMeter : UIControl
     /// Font
     
     /// Font attributes
-    private var fontAttributtes:[NSAttributedStringKey:Any] = [:]
+    private var fontAttributtes:[NSAttributedString.Key:Any] = [:]
     
     ///Font name (default:HelveticaNeue-Light)
     public var fontName:String = "HelveticaNeue-Light" {
@@ -276,13 +276,13 @@ public class OMMeter : UIControl
             size: stringSizeToFit)
         // Configure the font attributes
         paragraphStyle.alignment = .center
-        fontAttributtes = [NSAttributedStringKey.font: UIFont(name: fontName, size: stringMaxSize.height)!,
-                           NSAttributedStringKey.paragraphStyle: paragraphStyle,
-                           NSAttributedStringKey.foregroundColor: fontColor,
+        fontAttributtes = [NSAttributedString.Key.font: UIFont(name: fontName, size: stringMaxSize.height)!,
+                           NSAttributedString.Key.paragraphStyle: paragraphStyle,
+                           NSAttributedString.Key.foregroundColor: fontColor,
                            // https://developer.apple.com/library/content/qa/qa1531/_index.html
             // Supply a negative value for stroke width that is 2% of the font point size in thickness
-            NSAttributedStringKey.strokeWidth:NSNumber(value:-2.0),
-            NSAttributedStringKey.strokeColor:UIColor.white]
+            NSAttributedString.Key.strokeWidth:NSNumber(value:-2.0),
+            NSAttributedString.Key.strokeColor:UIColor.white]
         
         setNeedsDisplay()
     }

--- a/Package.swift
+++ b/Package.swift
@@ -1,0 +1,25 @@
+// swift-tools-version:5.0
+
+import PackageDescription
+
+#if os(macOS)
+let package = Package(
+    name: "OMMeter",
+    products: [
+        .library(
+            name: "OMMeter",
+            targets: ["OMMeter"]),
+    ],
+    dependencies: [],
+    targets: [
+        .target(
+            name: "OMMeter",
+            dependencies: [],
+            path: "OMMeter/Classes",
+            exclude: ["Example", "ScreenShot", "README.md", "LICENSE", "OMMeter.podspec"]
+        ),
+    ]
+)
+#else
+fatalError("Unsupported OS")
+#endif


### PR DESCRIPTION
Adding Package.swift makes OMMeter directly importable from Xcode 11's Github integration, and anything else that uses Swift Package Manager. This was the primary reason I forked and made these changes, and I have successfully re-integrated OMMeter into an existing project using this methodology instead of the previous manual approach.

The changes to NSAttributedStringKey are to avoid warnings in Swift 5.

Lastly, the @unknown default enum case also avoids a warning in Swift 5 but could (if someone wanted to) be replaced with something better than a fatalError() in future for more graceful error handling.